### PR TITLE
Optimize CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 services:
   - docker
+  - postgresql
 
 env:
   - GO111MODULE=on LINT_VER=v1.17.1 KIND_VER=v0.3.0
@@ -20,6 +21,9 @@ jobs:
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $LINT_VER
       script: make lint
     - stage: unit and integration tests
+      before_script:
+        - psql -c "CREATE DATABASE papi_db;" -U postgres
+        - psql -c "CREATE USER papi_user WITH PASSWORD 'p4p1_p455';" -U postgres
       script:
         - make test.unit
         - make test.integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ services:
   - docker
 
 env:
-  - GO111MODULE=on KIND_VER=v0.3.0
+  - GO111MODULE=on LINT_VER=v1.17.1 KIND_VER=v0.3.0
 
 jobs:
   include:
     - stage: lint
+      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $LINT_VER
       script: make lint
     - stage: unit and integration tests
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,29 +14,35 @@ services:
 env:
   - GO111MODULE=on KIND_VER=v0.3.0
 
-install:
-  - curl -Lo $HOME/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VER/kind-linux-amd64
-  - chmod +x $HOME/bin/kind
-  - kind version
-  - curl -Lo $HOME/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-  - chmod +x $HOME/bin/kubectl
-  - kubectl version --client --short
-
-before_script:
-  - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-
-script:
-  - make lint
-  - make test.unit
-  - make test.integration
-  - make build
-  - make docker.build
-  - make docker.push
-  - make test.e2e.k8s
-  - make terraform.chkfmt
-  - make terraform.init
-  - make terraform.keygen
-  - make terraform.validate
-  - make terraform.apply
-  - make test.e2e
-  - make terraform.destroy
+jobs:
+  include:
+    - stage: lint
+      script: make lint
+    - stage: unit and integration tests
+      script:
+        - make test.unit
+        - make test.integration
+    - stage: build and push docker test image
+      before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      script:
+        - make docker.build
+        - make docker.push
+    - stage: e2e tests (k8s)
+      install:
+        - curl -Lo $HOME/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VER/kind-linux-amd64
+        - chmod +x $HOME/bin/kind
+        - kind version
+        - curl -Lo $HOME/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        - chmod +x $HOME/bin/kubectl
+        - kubectl version --client --short
+      script: make test.e2e.k8s
+    - stage: e2e tests (AWS)
+      script:
+        - make build
+        - make terraform.chkfmt
+        - make terraform.init
+        - make terraform.keygen
+        - make terraform.validate
+        - make terraform.apply
+        - make test.e2e
+        - make terraform.destroy

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
         - kubectl version --client --short
       script: make test.e2e.k8s
     - stage: e2e tests (AWS)
+      if: branch = master
       script:
         - make build
         - make terraform.chkfmt

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ TARGET_ARCH ?= amd64
 SWAGGER_VER ?= v0.19.0
 SWAGGER = docker run --rm -e GOPATH=/go -v "$(PWD)":"$(PWD)" -w "$(PWD)" quay.io/goswagger/swagger:$(SWAGGER_VER)
 
-GOLANGCI_LINT_VER ?= v1.16.0
-GOLANGCI_LINT = docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" golangci/golangci-lint:$(GOLANGCI_LINT_VER)
-
 POSTGRES_VER ?= 11.3-alpine
 CONTAINER_NAME = db
 DB_HOST ?= localhost
@@ -57,7 +54,7 @@ swagger.generate.client:
 	$(SWAGGER) generate client --spec=$(SPEC) --template=stratoscale --target=$(PKG) --skip-models
 
 lint:
-	$(GOLANGCI_LINT) golangci-lint run --no-config --skip-dirs "$(PKG)/(client|models|restapi)" --deadline 2m
+	golangci-lint run --no-config --skip-dirs "$(PKG)/(client|models|restapi)" --deadline 2m
 
 test.unit:
 	$(GO) test -v -race ./$(PKG)/service

--- a/cmd/server/handlers_test.go
+++ b/cmd/server/handlers_test.go
@@ -16,7 +16,7 @@ func TestHealth(t *testing.T) {
 		t.Fatalf("Error creating mock connection: %v", err)
 	}
 
-	badConn, err := sql.Open("postgres", "")
+	badConn, err := sql.Open("postgres", "host=bad.host")
 	if err != nil {
 		t.Fatalf("Error creating bad connection: %v", err)
 	}


### PR DESCRIPTION
The original Travis configuration was basically doing every step in a single job. Structuring the build process into different stages allows for a failing stage to stop the whole process, implementing a fail-fast approach where needed. It also allows skipping specific stages conditionally depending on the branch being built.

Besides that, some other changes are targeted at reusing previous artifacts as caches and looking for alternatives that are faster to use, such as the case with the golangci-lint docker image being much slower to download and use compared with using the release binary.