### PR TITLE
Fix pushing images from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - make test.e2e
         - make terraform.destroy
     - stage: push to Docker Hub
-      if: branch = master AND tag IS present
+      if: tag IS present
       before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       script:
         - docker build -t $DOCKER_REPO:$TRAVIS_TAG .


### PR DESCRIPTION
The condition to push an image from Travis included, not only that the commit was tagged, but also that the commit belonged to master. However, when building a tagged commit Travis doesn't have information about what branch the commit belongs to.